### PR TITLE
Add boolean to run from workspace root

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -11,7 +11,7 @@ useful for running multiple linters or formatters with a single command.
 <pre>
 load("@rules_multirun//:defs.bzl", "command")
 
-command(<a href="#command-name">name</a>, <a href="#command-data">data</a>, <a href="#command-arguments">arguments</a>, <a href="#command-command">command</a>, <a href="#command-description">description</a>, <a href="#command-environment">environment</a>)
+command(<a href="#command-name">name</a>, <a href="#command-data">data</a>, <a href="#command-arguments">arguments</a>, <a href="#command-command">command</a>, <a href="#command-description">description</a>, <a href="#command-environment">environment</a>, <a href="#command-run_from_workspace_root">run_from_workspace_root</a>)
 </pre>
 
 A command is a wrapper rule for some other target that can be run like a
@@ -58,6 +58,7 @@ command(
 | <a id="command-command"></a>command |  Target to run   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="command-description"></a>description |  A string describing the command printed during multiruns   | String | optional |  `""`  |
 | <a id="command-environment"></a>environment |  Dictionary of environment variables. Subject to $(location) expansion. See https://docs.bazel.build/versions/master/skylark/lib/ctx.html#expand_location   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="command-run_from_workspace_root"></a>run_from_workspace_root |  If true, the command will be run from the workspace root instead of the execution root   | Boolean | optional |  `False`  |
 
 
 <a id="command_force_opt"></a>
@@ -67,7 +68,7 @@ command(
 <pre>
 load("@rules_multirun//:defs.bzl", "command_force_opt")
 
-command_force_opt(<a href="#command_force_opt-name">name</a>, <a href="#command_force_opt-data">data</a>, <a href="#command_force_opt-arguments">arguments</a>, <a href="#command_force_opt-command">command</a>, <a href="#command_force_opt-description">description</a>, <a href="#command_force_opt-environment">environment</a>)
+command_force_opt(<a href="#command_force_opt-name">name</a>, <a href="#command_force_opt-data">data</a>, <a href="#command_force_opt-arguments">arguments</a>, <a href="#command_force_opt-command">command</a>, <a href="#command_force_opt-description">description</a>, <a href="#command_force_opt-environment">environment</a>, <a href="#command_force_opt-run_from_workspace_root">run_from_workspace_root</a>)
 </pre>
 
 A command that forces the compilation mode of the dependent targets to opt. This can be useful if your tools have improved performance if built with optimizations. See the documentation for command for more examples. If you'd like to always use this variation you can import this directly and rename it for convenience like:
@@ -87,6 +88,7 @@ load("@rules_multirun//:defs.bzl", "multirun", command = "command_force_opt")
 | <a id="command_force_opt-command"></a>command |  Target to run   | <a href="https://bazel.build/concepts/labels">Label</a> | required |  |
 | <a id="command_force_opt-description"></a>description |  A string describing the command printed during multiruns   | String | optional |  `""`  |
 | <a id="command_force_opt-environment"></a>environment |  Dictionary of environment variables. Subject to $(location) expansion. See https://docs.bazel.build/versions/master/skylark/lib/ctx.html#expand_location   | <a href="https://bazel.build/rules/lib/dict">Dictionary: String -> String</a> | optional |  `{}`  |
+| <a id="command_force_opt-run_from_workspace_root"></a>run_from_workspace_root |  If true, the command will be run from the workspace root instead of the execution root   | Boolean | optional |  `False`  |
 
 
 <a id="multirun"></a>

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -227,10 +227,32 @@ multirun(
     print_command = False,
 )
 
+sh_binary(
+    name = "default_pwd",
+    srcs = ["default-pwd.sh"],
+)
+
+command(
+    name = "default_pwd_cmd",
+    command = ":default_pwd",
+)
+
+sh_binary(
+    name = "workspace_pwd",
+    srcs = ["workspace-pwd.sh"],
+)
+
+command(
+    name = "workspace_pwd_cmd",
+    command = ":workspace_pwd",
+    run_from_workspace_root = True,
+)
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     data = [
+        ":default_pwd_cmd",
         ":echo_and_fail_cmd",
         ":hello",
         ":hello2",
@@ -251,6 +273,7 @@ sh_test(
         ":validate_args_cmd_description",
         ":validate_chdir_location_cmd",
         ":validate_env_cmd",
+        ":workspace_pwd_cmd",
     ],
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )

--- a/tests/default-pwd.sh
+++ b/tests/default-pwd.sh
@@ -2,9 +2,7 @@
 
 set -euo pipefail
 
-set -x
-
-if [[ "$PWD" == "$BUILD_WORKSPACE_DIRECTORY" ]]; then
+if [[ "$PWD" -ef "$BUILD_WORKSPACE_DIRECTORY" ]]; then
   echo "error: expected to run from default pwd" >&2
   exit 1
 fi

--- a/tests/default-pwd.sh
+++ b/tests/default-pwd.sh
@@ -2,6 +2,8 @@
 
 set -euo pipefail
 
+set -x
+
 if [[ "$PWD" == "$BUILD_WORKSPACE_DIRECTORY" ]]; then
   echo "error: expected to run from default pwd" >&2
   exit 1

--- a/tests/default-pwd.sh
+++ b/tests/default-pwd.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ "$PWD" == "$BUILD_WORKSPACE_DIRECTORY" ]]; then
+  echo "error: expected to run from default pwd" >&2
+  exit 1
+fi

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -123,3 +123,10 @@ for expectation in "${expectations[@]}"; do
     exit 1
   fi
 done
+
+# Fake the 'bazel run' env var for tests
+export BUILD_WORKSPACE_DIRECTORY=/tmp
+script=$(rlocation rules_multirun/tests/default_pwd_cmd.bash)
+$script
+script=$(rlocation rules_multirun/tests/workspace_pwd_cmd.bash)
+$script

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -124,6 +124,7 @@ for expectation in "${expectations[@]}"; do
   fi
 done
 
+set -x
 # Fake the 'bazel run' env var for tests
 export BUILD_WORKSPACE_DIRECTORY=/tmp
 script=$(rlocation rules_multirun/tests/default_pwd_cmd.bash)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -124,7 +124,6 @@ for expectation in "${expectations[@]}"; do
   fi
 done
 
-set -x
 # Fake the 'bazel run' env var for tests
 export BUILD_WORKSPACE_DIRECTORY=/tmp
 script=$(rlocation rules_multirun/tests/default_pwd_cmd.bash)

--- a/tests/workspace-pwd.sh
+++ b/tests/workspace-pwd.sh
@@ -1,9 +1,8 @@
 #!/bin/bash
 
 set -euo pipefail
-set -x
 
-if [[ "$PWD" != "$BUILD_WORKSPACE_DIRECTORY" ]]; then
+if [[ ! "$PWD" -ef "$BUILD_WORKSPACE_DIRECTORY" ]]; then
   echo "error: expected to run from workspace root" >&2
   exit 1
 fi

--- a/tests/workspace-pwd.sh
+++ b/tests/workspace-pwd.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 
 set -euo pipefail
+set -x
 
 if [[ "$PWD" != "$BUILD_WORKSPACE_DIRECTORY" ]]; then
   echo "error: expected to run from workspace root" >&2

--- a/tests/workspace-pwd.sh
+++ b/tests/workspace-pwd.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+set -euo pipefail
+
+if [[ "$PWD" != "$BUILD_WORKSPACE_DIRECTORY" ]]; then
+  echo "error: expected to run from workspace root" >&2
+  exit 1
+fi


### PR DESCRIPTION
This is common for tools like linters. Doing the cd themselves is fine,
but maybe this is nicer
