### PR TITLE
Forward *_binary args and env to multirun

### DIFF
--- a/multirun.bzl
+++ b/multirun.bzl
@@ -18,6 +18,16 @@ def _binary_args_env_aspect_impl(target, ctx):
     env = getattr(ctx.rule.attr, "env", {})
 
     if is_executable and (args or env):
+        expansion_targets = getattr(ctx.rule.attr, "data")
+        if expansion_targets:
+            args = [
+                ctx.expand_location(arg, expansion_targets)
+                for arg in args
+            ]
+            env = {
+                name: ctx.expand_location(val, expansion_targets)
+                for name, val in env.items()
+            }
         return [_BinaryArgsEnvInfo(args = args, env = env)]
 
     return []

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -7,6 +7,25 @@ in a single invocation.
 load("@bazel_skylib//lib:shell.bzl", "shell")
 load("//internal:constants.bzl", "RUNFILES_PREFIX")
 
+_BinaryArgsEnvInfo = provider(fields = ["args", "env"])
+
+def _binary_args_env_aspect_impl(target, ctx):
+    if _BinaryArgsEnvInfo in target:
+        return []
+
+    is_executable = target.files_to_run != None and target.files_to_run.executable != None
+    args = getattr(ctx.rule.attr, "args", [])
+    env = getattr(ctx.rule.attr, "env", {})
+
+    if is_executable and (args or env):
+        return [_BinaryArgsEnvInfo(args = args, env = env)]
+
+    return []
+
+_binary_args_env_aspect = aspect(
+    implementation = _binary_args_env_aspect_impl,
+)
+
 def _multirun_impl(ctx):
     instructions_file = ctx.actions.declare_file(ctx.label.name + ".json")
     runner_info = ctx.attr._runner[DefaultInfo]
@@ -39,12 +58,20 @@ def _multirun_impl(ctx):
             fail("%s does not have an executable file" % command.label, attr = "commands")
         runfiles_files.append(exe)
 
+        args = []
+        env = {}
+        if _BinaryArgsEnvInfo in command:
+            args = command[_BinaryArgsEnvInfo].args
+            env = command[_BinaryArgsEnvInfo].env
+
         default_runfiles = default_info.default_runfiles
         if default_runfiles != None:
             runfiles = runfiles.merge(default_runfiles)
         commands.append(struct(
             tag = tag,
             path = exe.short_path,
+            args = args,
+            env = env,
         ))
 
     if ctx.attr.jobs < 0:
@@ -82,6 +109,7 @@ multirun = rule(
         "commands": attr.label_list(
             mandatory = False,
             allow_files = True,
+            aspects = [_binary_args_env_aspect],
             doc = "Targets to run",
             cfg = "target",
         ),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -93,12 +93,25 @@ multirun(
     commands = [":validate_binary_env"],
 )
 
+sh_binary(
+    name = "validate_binary_args_location",
+    args = ["$(rlocationpath :hello)"],
+    data = [":hello"],
+    srcs = ["validate-chdir-location.sh"],
+)
+
+multirun(
+    name = "multirun_binary_args_location",
+    commands = [":validate_binary_args_location"],
+)
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     data = [
         ":hello",
         ":multirun_binary_args",
+        ":multirun_binary_args_location",
         ":multirun_binary_env",
         ":multirun_parallel",
         ":multirun_serial",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -71,11 +71,35 @@ multirun(
     print_command = False,
 )
 
+sh_binary(
+    name = "validate_binary_args",
+    args = ["foo"],
+    srcs = ["validate-args.sh"],
+)
+
+multirun(
+    name = "multirun_binary_args",
+    commands = [":validate_binary_args"],
+)
+
+sh_binary(
+    name = "validate_binary_env",
+    env = {"FOO_ENV": "foo"},
+    srcs = ["validate-env.sh"],
+)
+
+multirun(
+    name = "multirun_binary_env",
+    commands = [":validate_binary_env"],
+)
+
 sh_test(
     name = "test",
     srcs = ["test.sh"],
     data = [
         ":hello",
+        ":multirun_binary_args",
+        ":multirun_binary_env",
         ":multirun_parallel",
         ":multirun_serial",
         ":multirun_serial_no_print",

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -28,6 +28,11 @@ $script
 script=$(rlocation rules_multirun/tests/validate_env_cmd.bash)
 $script
 
+script=$(rlocation rules_multirun/tests/multirun_binary_args.bash)
+$script
+script=$(rlocation rules_multirun/tests/multirun_binary_env.bash)
+$script
+
 script="$(rlocation rules_multirun/tests/multirun_parallel.bash)"
 parallel_output="$($script)"
 if [[ -n "$parallel_output" ]]; then

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -32,6 +32,8 @@ script=$(rlocation rules_multirun/tests/multirun_binary_args.bash)
 $script
 script=$(rlocation rules_multirun/tests/multirun_binary_env.bash)
 $script
+script=$(rlocation rules_multirun/tests/multirun_binary_args_location.bash)
+$script
 
 script="$(rlocation rules_multirun/tests/multirun_parallel.bash)"
 parallel_output="$($script)"

--- a/tests/validate-args.sh
+++ b/tests/validate-args.sh
@@ -2,12 +2,12 @@
 
 set -euo pipefail
 
-if [[ "$1" != "foo" ]]; then
-  echo "error: expected first arg to be 'foo', got '$1'"
+if [[ $# -ne 1 ]]; then
+  echo "error: expected 1 arg, got $#, args: $*"
   exit 1
 fi
 
-if [[ $# -ne 1 ]]; then
-  echo "error: expected 1 arg, got $#, args: $*"
+if [[ "$1" != "foo" ]]; then
+  echo "error: expected first arg to be 'foo', got '$1'"
   exit 1
 fi


### PR DESCRIPTION
Closes #3

This is a convenient feature to have to integrate `rules_multirun` with existing `*_binary` targets that already have `args` and `env` attributes set without having to duplicate these attributes on an intermediate `command` target.

This PR adds an `aspect` that collects the [common `args` and `env` attributes of `*_binary` rules](https://bazel.build/reference/be/common-definitions#common-attributes-binaries), taking location expansion into account.
It applies said `aspect` to the `commands` attribute of `multirun` and forwards the `args` and `env` to `multirun.py`.
And it changes `multirun.py` to forward the `args` and `env` to the target command.

It also adds test cases for args and env forwarding, including location expansion.


