### PR TITLE
Add command_with_transition macro.

### DIFF
--- a/defs.bzl
+++ b/defs.bzl
@@ -1,8 +1,11 @@
 """Export APIs for easier use, see specific files for details"""
 
-load(":command.bzl", _command = "command")
+load(":command.bzl", _command = "command", _command_force_opt = "command_force_opt", _command_with_transition = "command_with_transition")
 load(":multirun.bzl", _multirun = "multirun", _multirun_with_transition = "multirun_with_transition")
 
 command = _command
+command_force_opt = _command_force_opt
+command_with_transition = _command_with_transition
+
 multirun = _multirun
 multirun_with_transition = _multirun_with_transition

--- a/internal/constants.bzl
+++ b/internal/constants.bzl
@@ -19,3 +19,23 @@ source "${RUNFILES_DIR:-/dev/null}/$f" 2>/dev/null || \\
 runfiles_export_envvars
 
 """
+
+def update_attrs(attrs, cfg, allowlist):
+    """Conditionally update attributes.
+
+    Arguments:
+        attrs: Attributes dictionary.
+        cfg: The command configuration.
+        allowlist: Optional allow list label that will be applied to the configuration transition.
+    Returns:
+        Updated attributes dictionary.
+    """
+    if type(cfg) == "transition":
+        # Configurations declared as StarlarkDefinedConfigTransition instances
+        # (https://github.com/bazelbuild/bazel/blob/e2189245/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java#L443)
+        # require a "_allowlist_function_transition" attribute in the rule definition at
+        # https://github.com/bazelbuild/bazel/blob/e2189245/src/main/java/com/google/devtools/build/lib/analysis/starlark/StarlarkRuleClassFunctions.java#L924-L933
+        # Set the provided allow list label or default one .
+        attrs["_allowlist_function_transition"] = attr.label(default = allowlist or "@bazel_tools//tools/allowlists/function_transition_allowlist")
+
+    return attrs

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -5,7 +5,7 @@ in a single invocation.
 """
 
 load("@bazel_skylib//lib:shell.bzl", "shell")
-load("//internal:constants.bzl", "RUNFILES_PREFIX")
+load("//internal:constants.bzl", "RUNFILES_PREFIX", "update_attrs")
 
 _BinaryArgsEnvInfo = provider(fields = ["args", "env"])
 
@@ -144,12 +144,9 @@ def multirun_with_transition(cfg, allowlist = None):
         ),
     }
 
-    if allowlist:
-        attrs["_allowlist_function_transition"] = attr.label(default = allowlist)
-
     return rule(
         implementation = _multirun_impl,
-        attrs = attrs,
+        attrs = update_attrs(attrs, cfg, allowlist),
         executable = True,
     )
 

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,5 +1,5 @@
-load("//:defs.bzl", "command", "multirun")
-load(":transitions.bzl", "multirun_lambda")
+load("//:defs.bzl", "command", "command_force_opt", "multirun")
+load(":transitions.bzl", "command_lambda", "multirun_lambda")
 
 sh_binary(
     name = "echo_hello",
@@ -28,7 +28,7 @@ sh_binary(
     deps = ["@bazel_tools//tools/bash/runfiles"],
 )
 
-command(
+command_force_opt(
     name = "validate_chdir_location_cmd",
     arguments = ["$(rlocationpath :hello)"],
     command = "validate_chdir_location",
@@ -40,7 +40,7 @@ sh_binary(
     srcs = ["validate-env.sh"],
 )
 
-command(
+command_lambda(
     name = "validate_env_cmd",
     command = "validate_env",
     environment = {"FOO_ENV": "foo"},
@@ -74,8 +74,8 @@ multirun(
 
 sh_binary(
     name = "validate_binary_args",
-    args = ["foo"],
     srcs = ["validate-args.sh"],
+    args = ["foo"],
 )
 
 multirun(
@@ -85,8 +85,8 @@ multirun(
 
 sh_binary(
     name = "validate_binary_env",
-    env = {"FOO_ENV": "foo"},
     srcs = ["validate-env.sh"],
+    env = {"FOO_ENV": "foo"},
 )
 
 multirun(
@@ -110,9 +110,9 @@ multirun_lambda(
 
 sh_binary(
     name = "validate_binary_args_location",
+    srcs = ["validate-chdir-location.sh"],
     args = ["$(rlocationpath :hello)"],
     data = [":hello"],
-    srcs = ["validate-chdir-location.sh"],
 )
 
 multirun(

--- a/tests/transitions.bzl
+++ b/tests/transitions.bzl
@@ -1,4 +1,4 @@
-load("//:defs.bzl", "multirun_with_transition")
+load("//:defs.bzl", "command_with_transition", "multirun_with_transition")
 
 def _platform_transition_impl(settings, attr):
     return {"//command_line_option:platforms": [":lambda"]}
@@ -7,6 +7,11 @@ platform_transition = transition(
     implementation = _platform_transition_impl,
     inputs = [],
     outputs = ["//command_line_option:platforms"],
+)
+
+command_lambda = command_with_transition(
+    platform_transition,
+    "@bazel_tools//tools/allowlists/function_transition_allowlist",
 )
 
 multirun_lambda = multirun_with_transition(


### PR DESCRIPTION
@keith I have prepared another PR that breaks the current behavior which forces commands to make a transition to the "opt" compilation mode. Such implicit transition requires rebuilds of dependencies if a non-"opt" mode is used for building and testing before running multirun targets. In my example building of an image is done in the default `fastbuild` mode:
```
bazel build --platforms //deploy:aws_batch //src:image -s
...
  bazel-out/darwin_arm64-fastbuild-ST-445ab20d0084/bin/src/layer.build)
# Configuration: 0bee61ed503b09c25677365e3af314e0bdc31e8c9a0fdadd7381edaeff2222ab
...
```
but deploying the pre-built image with a multirun rule `deploy` forces another rebuild in `opt` mode`
```
bazel build //deploy:aws_batch //src:deploy -s
...
  bazel-out/darwin_arm64-opt-ST-445ab20d0084/bin/src/layer.build)
# Configuration: 318688f3701ef1fef848ac612bbc338ed2687e6287631dbcfc5499a3febae5d0
```
which involves Docker create commands and takes some minutes.

The PR is similar to #17:
* adds `command_with_transition` macro
* aligns `multirun` and `command` configurations to "target"
* adds `command_force_opt` which keeps previous behavior of `command`
* updates some tests