### PR TITLE
prefixing command path with ./

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -13,7 +13,7 @@ class Command(NamedTuple):
 
 
 def _run_command(command: Command, block: bool):
-    args = [command.path] + command.args
+    args = ['./' + command.path] + command.args
     env = dict(os.environ)
     env.update(command.env)
     if block:


### PR DESCRIPTION
https://github.com/keith/rules_multirun/issues/19