### PR TITLE
Disable bazel lockfile

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -1,3 +1,5 @@
+common --lockfile_mode=off
+
 build --remote_cache=grpcs://remote.buildbuddy.io
 build --remote_timeout=3600
 


### PR DESCRIPTION
Otherwise when you go between bazel versions things fail
