### PR TITLE
Add keep_going for serial multiruns

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -33,17 +33,21 @@ def _perform_concurrently(commands: List[Command]) -> bool:
     return success
 
 
-def _perform_serially(commands: List[Command], print_command: bool) -> bool:
+def _perform_serially(commands: List[Command], print_command: bool, keep_going: bool) -> bool:
+    success = True
     for command in commands:
         if print_command:
-            print(f"Running {command.tag}")
+            print(f"Running {command.tag}", flush=True)
 
         try:
             _run_command(command, block=True)
         except subprocess.CalledProcessError:
-            return False
+            if keep_going:
+                success = False
+            else:
+                return False
 
-    return True
+    return success
 
 
 def _main(path: str) -> None:
@@ -58,7 +62,7 @@ def _main(path: str) -> None:
     if parallel:
         success = _perform_concurrently(commands)
     else:
-        success = _perform_serially(commands, instructions["print_command"])
+        success = _perform_serially(commands, instructions["print_command"], instructions["keep_going"])
 
     sys.exit(0 if success else 1)
 

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -92,6 +92,7 @@ def _multirun_impl(ctx):
         commands = commands,
         jobs = jobs,
         print_command = ctx.attr.print_command,
+        keep_going = ctx.attr.keep_going,
     )
     ctx.actions.write(
         output = instructions_file,
@@ -133,6 +134,10 @@ def multirun_with_transition(cfg, allowlist = None):
         "print_command": attr.bool(
             default = True,
             doc = "Print what command is being run before running it. Only for sequential execution.",
+        ),
+        "keep_going": attr.bool(
+            default = False,
+            doc = "Keep going after a command fails. Only for sequential execution.",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -73,7 +73,6 @@ multirun(
         ":validate_args_cmd",
         ":validate_env_cmd",
     ],
-    keep_going = True,
 )
 
 multirun(

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,6 +13,17 @@ command(
 )
 
 sh_binary(
+    name = "echo_and_fail",
+    srcs = ["echo_and_fail.sh"],
+    visibility = ["//:__subpackages__"],
+)
+
+command(
+    name = "echo_and_fail_cmd",
+    command = "echo_and_fail",
+)
+
+sh_binary(
     name = "validate_args",
     srcs = ["validate-args.sh"],
 )
@@ -62,6 +73,16 @@ multirun(
         ":validate_args_cmd",
         ":validate_env_cmd",
     ],
+    keep_going = True,
+)
+
+multirun(
+    name = "multirun_serial_keep_going",
+    commands = [
+        ":echo_and_fail",
+        ":echo_hello",
+    ],
+    keep_going = True,
 )
 
 multirun(
@@ -131,12 +152,14 @@ sh_test(
     name = "test",
     srcs = ["test.sh"],
     data = [
+        ":echo_and_fail_cmd",
         ":hello",
         ":multirun_binary_args",
         ":multirun_binary_args_location",
         ":multirun_binary_env",
         ":multirun_parallel",
         ":multirun_serial",
+        ":multirun_serial_keep_going",
         ":multirun_serial_no_print",
         ":multirun_with_transition",
         ":root_multirun",

--- a/tests/echo_and_fail.sh
+++ b/tests/echo_and_fail.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo 'hello and fail'
+exit 1

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -53,6 +53,20 @@ Running @//tests:validate_env_cmd" ]]; then
   exit 1
 fi
 
+script=$(rlocation rules_multirun/tests/multirun_serial_keep_going.bash)
+if serial_output=$($script | sed 's=@[^/]*/=@/=g'); then
+  echo "Expected failure" >&2
+  exit 1
+fi
+
+if [[ "$serial_output" != "Running @//tests:echo_and_fail
+hello and fail
+Running @//tests:echo_hello
+hello" ]]; then
+  echo "Expected labeled output, got '$serial_output'"
+  exit 1
+fi
+
 script=$(rlocation rules_multirun/tests/multirun_serial_no_print.bash)
 serial_no_output=$($script)
 if [[ -n "$serial_no_output" ]]; then


### PR DESCRIPTION
This allows you to run all serial tasks and then fail if any of them
failed. This can be useful if you want to see all the results, instead
of stopping ASAP

Fixes https://github.com/keith/rules_multirun/issues/30
