### PR TITLE
Buffer multirun output by default

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -148,7 +148,7 @@ multiple tools.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="multirun-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="multirun-data"></a>data |  The list of files needed by the commands at runtime. See general comments about `data` at https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
-| <a id="multirun-buffer_output"></a>buffer_output |  Buffer the output of the commands and print it after the command has finished. Only for parallel execution.   | Boolean | optional |  `True`  |
+| <a id="multirun-buffer_output"></a>buffer_output |  Buffer the output of the commands and print it after each command has finished. Only for parallel execution.   | Boolean | optional |  `False`  |
 | <a id="multirun-commands"></a>commands |  Targets to run   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="multirun-jobs"></a>jobs |  The expected concurrency of targets to be executed. Default is set to 1 which means sequential execution. Setting to 0 means that there is no limit concurrency.   | Integer | optional |  `1`  |
 | <a id="multirun-keep_going"></a>keep_going |  Keep going after a command fails. Only for sequential execution.   | Boolean | optional |  `False`  |

--- a/doc/README.md
+++ b/doc/README.md
@@ -90,7 +90,7 @@ load("@rules_multirun//:defs.bzl", "multirun", command = "command_force_opt")
 ## multirun
 
 <pre>
-multirun(<a href="#multirun-name">name</a>, <a href="#multirun-data">data</a>, <a href="#multirun-commands">commands</a>, <a href="#multirun-jobs">jobs</a>, <a href="#multirun-keep_going">keep_going</a>, <a href="#multirun-print_command">print_command</a>)
+multirun(<a href="#multirun-name">name</a>, <a href="#multirun-data">data</a>, <a href="#multirun-buffer_output">buffer_output</a>, <a href="#multirun-commands">commands</a>, <a href="#multirun-jobs">jobs</a>, <a href="#multirun-keep_going">keep_going</a>, <a href="#multirun-print_command">print_command</a>)
 </pre>
 
 A multirun composes multiple command rules in order to run them in a single
@@ -148,10 +148,11 @@ multiple tools.
 | :------------- | :------------- | :------------- | :------------- | :------------- |
 | <a id="multirun-name"></a>name |  A unique name for this target.   | <a href="https://bazel.build/concepts/labels#target-names">Name</a> | required |  |
 | <a id="multirun-data"></a>data |  The list of files needed by the commands at runtime. See general comments about `data` at https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="multirun-buffer_output"></a>buffer_output |  Buffer the output of the commands and print it after the command has finished. Only for parallel execution.   | Boolean | optional |  `True`  |
 | <a id="multirun-commands"></a>commands |  Targets to run   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="multirun-jobs"></a>jobs |  The expected concurrency of targets to be executed. Default is set to 1 which means sequential execution. Setting to 0 means that there is no limit concurrency.   | Integer | optional |  `1`  |
 | <a id="multirun-keep_going"></a>keep_going |  Keep going after a command fails. Only for sequential execution.   | Boolean | optional |  `False`  |
-| <a id="multirun-print_command"></a>print_command |  Print what command is being run before running it. Only for sequential execution.   | Boolean | optional |  `True`  |
+| <a id="multirun-print_command"></a>print_command |  Print what command is being run before running it.   | Boolean | optional |  `True`  |
 
 
 <a id="command_with_transition"></a>

--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -12,21 +12,40 @@ class Command(NamedTuple):
     env: Dict[str, str]
 
 
-def _run_command(command: Command, block: bool) -> Union[int, subprocess.Popen]:
+def _run_command(command: Command, block: bool, **kwargs) -> Union[int, subprocess.Popen]:
     args = ['./' + command.path] + command.args
     env = dict(os.environ)
     env.update(command.env)
     if block:
         return subprocess.check_call(args, env=env)
     else:
-        return subprocess.Popen(args, env=env)
+        return subprocess.Popen(args, env=env, **kwargs)
 
 
-def _perform_concurrently(commands: List[Command]) -> bool:
-    processes = [_run_command(command, block=False) for command in commands]
+def _perform_concurrently(commands: List[Command], print_command: bool, buffer_output: bool) -> bool:
+    kwargs = {}
+    if buffer_output:
+        kwargs = {
+             "stdout" : subprocess.PIPE,
+             "stderr" : subprocess.STDOUT
+        }
+
+    processes = [
+        (command, _run_command(command, block=False, **kwargs))
+        for command
+        in commands
+    ]
+
     success = True
-    for process in processes:
+    for command, process in processes:
         process.wait()
+        if print_command and buffer_output:
+            print(command.tag, flush=True)
+
+        stdout = process.communicate()[0]
+        if stdout:
+            print(stdout.decode().strip(), flush=True)
+
         if process.returncode != 0:
             success = False
 
@@ -59,10 +78,11 @@ def _main(path: str) -> None:
         for blob in instructions["commands"]
     ]
     parallel = instructions["jobs"] == 0
+    print_command: bool = instructions["print_command"]
     if parallel:
-        success = _perform_concurrently(commands)
+        success = _perform_concurrently(commands, print_command, instructions["buffer_output"])
     else:
-        success = _perform_serially(commands, instructions["print_command"], instructions["keep_going"])
+        success = _perform_serially(commands, print_command, instructions["keep_going"])
 
     sys.exit(0 if success else 1)
 

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -106,6 +106,7 @@ def _multirun_impl(ctx):
         jobs = jobs,
         print_command = ctx.attr.print_command,
         keep_going = ctx.attr.keep_going,
+        buffer_output = ctx.attr.buffer_output,
     )
     ctx.actions.write(
         output = instructions_file,
@@ -155,11 +156,15 @@ def multirun_with_transition(cfg, allowlist = None):
         ),
         "print_command": attr.bool(
             default = True,
-            doc = "Print what command is being run before running it. Only for sequential execution.",
+            doc = "Print what command is being run before running it.",
         ),
         "keep_going": attr.bool(
             default = False,
             doc = "Keep going after a command fails. Only for sequential execution.",
+        ),
+        "buffer_output": attr.bool(
+            default = True,
+            doc = "Buffer the output of the commands and print it after the command has finished. Only for parallel execution.",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -163,8 +163,8 @@ def multirun_with_transition(cfg, allowlist = None):
             doc = "Keep going after a command fails. Only for sequential execution.",
         ),
         "buffer_output": attr.bool(
-            default = True,
-            doc = "Buffer the output of the commands and print it after the command has finished. Only for parallel execution.",
+            default = False,
+            doc = "Buffer the output of the commands and print it after each command has finished. Only for parallel execution.",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -13,6 +13,17 @@ command(
 )
 
 sh_binary(
+    name = "echo_hello2",
+    srcs = ["echo_hello2.sh"],
+    visibility = ["//:__subpackages__"],
+)
+
+command(
+    name = "hello2",
+    command = "echo_hello2",
+)
+
+sh_binary(
     name = "echo_and_fail",
     srcs = ["echo_and_fail.sh"],
     visibility = ["//:__subpackages__"],
@@ -70,6 +81,26 @@ multirun(
     commands = [
         ":validate_args_cmd",
         ":validate_env_cmd",
+    ],
+    jobs = 0,
+    print_command = False,
+)
+
+multirun(
+    name = "multirun_parallel_no_buffer",
+    buffer_output = False,
+    commands = [
+        ":validate_args_cmd",
+        ":validate_env_cmd",
+    ],
+    jobs = 0,
+)
+
+multirun(
+    name = "multirun_parallel_with_output",
+    commands = [
+        ":echo_hello",
+        ":echo_hello2",
     ],
     jobs = 0,
 )
@@ -160,6 +191,7 @@ multirun(
     name = "root_multirun",
     commands = ["//:root_command"],
     jobs = 0,
+    print_command = False,
 )
 
 sh_test(
@@ -168,10 +200,13 @@ sh_test(
     data = [
         ":echo_and_fail_cmd",
         ":hello",
+        ":hello2",
         ":multirun_binary_args",
         ":multirun_binary_args_location",
         ":multirun_binary_env",
         ":multirun_parallel",
+        ":multirun_parallel_no_buffer",
+        ":multirun_parallel_with_output",
         ":multirun_serial",
         ":multirun_serial_description",
         ":multirun_serial_keep_going",

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -98,6 +98,7 @@ multirun(
 
 multirun(
     name = "multirun_parallel_with_output",
+    buffer_output = True,
     commands = [
         ":echo_hello",
         ":echo_hello2",

--- a/tests/echo_hello2.sh
+++ b/tests/echo_hello2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+
+set -euo pipefail
+
+echo 'hello2'

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -45,6 +45,23 @@ if [[ -n "$parallel_output" ]]; then
   exit 1
 fi
 
+script="$(rlocation rules_multirun/tests/multirun_parallel_no_buffer.bash)"
+parallel_output="$($script)"
+if [[ -n "$parallel_output" ]]; then
+  echo "Expected no output, got '$parallel_output'"
+  exit 1
+fi
+
+script="$(rlocation rules_multirun/tests/multirun_parallel_with_output.bash)"
+parallel_output=$($script | sed 's=@[^/]*/=@/=g')
+if [[ "$parallel_output" != "Running @//tests:echo_hello
+hello
+Running @//tests:echo_hello2
+hello2" ]]; then
+  echo "Expected output, got '$parallel_output'"
+  exit 1
+fi
+
 script=$(rlocation rules_multirun/tests/multirun_serial.bash)
 serial_output=$($script | sed 's=@[^/]*/=@/=g')
 if [[ "$serial_output" != "Running @//tests:validate_args_cmd


### PR DESCRIPTION
This is more sensible printing of parallel jobs so different output
isn't combined. This flips the default and can be negated with
`buffer_output = False`. This also makes `print_command` apply to
parallel multiruns
