### PR TITLE
Allow passing through arguments from bazel run

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -109,4 +109,4 @@ def _main(path: str) -> None:
 
 
 if __name__ == "__main__":
-    _main(sys.argv[-1])
+    _main(sys.argv[1])

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -118,7 +118,7 @@ def _multirun_impl(ctx):
     script = """\
 multirun_script="$(rlocation {})"
 instructions="$(rlocation {})"
-exec "$multirun_script" -f "$instructions"
+exec "$multirun_script" "$instructions" "$@"
 """.format(shell.quote(rlocation_path(ctx, runner_exe)), shell.quote(rlocation_path(ctx, instructions_file)))
     out_file = ctx.actions.declare_file(ctx.label.name + ".bash")
     ctx.actions.write(


### PR DESCRIPTION
Fixes https://github.com/keith/rules_multirun/issues/44
