### PR TITLE
Replace use of to_json() with json.encode()

### DIFF
--- a/multirun.bzl
+++ b/multirun.bzl
@@ -112,7 +112,7 @@ def _multirun_impl(ctx):
     )
     ctx.actions.write(
         output = instructions_file,
-        content = instructions.to_json(),
+        content = json.encode(instructions),
     )
 
     script = """\


### PR DESCRIPTION
The `to_json()` method is deprecated and will be removed. Using `json.encode()` is equivalent and should be used instead.