### PR TITLE
Set legacy_create_init = False

### DIFF
--- a/internal/BUILD
+++ b/internal/BUILD
@@ -4,6 +4,7 @@ load("@rules_python//python:defs.bzl", "py_binary")
 py_binary(
     name = "multirun",
     srcs = ["multirun.py"],
+    legacy_create_init = False,
     python_version = "PY3",
     visibility = ["//visibility:public"],
     deps = [


### PR DESCRIPTION
This virtually sets `--incompatible_default_to_explicit_init_py` which
might not be possible globally.
