### PR TITLE
feat: Support concurrency limit

### DIFF
--- a/tests/BUILD
+++ b/tests/BUILD
@@ -87,6 +87,17 @@ multirun(
 )
 
 multirun(
+    name = "multirun_parallel_limited_concurrency",
+    commands = [
+        "hello",
+        ":validate_args_cmd",
+        ":validate_env_cmd",
+    ],
+    jobs = 2,
+    print_command = False,
+)
+
+multirun(
     name = "multirun_parallel_no_buffer",
     buffer_output = False,
     commands = [
@@ -206,6 +217,7 @@ sh_test(
         ":multirun_binary_args_location",
         ":multirun_binary_env",
         ":multirun_parallel",
+        ":multirun_parallel_limited_concurrency",
         ":multirun_parallel_no_buffer",
         ":multirun_parallel_with_output",
         ":multirun_serial",

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -45,6 +45,13 @@ if [[ -n "$parallel_output" ]]; then
   exit 1
 fi
 
+script="$(rlocation rules_multirun/tests/multirun_parallel_limited_concurrency.bash)"
+parallel_output="$($script)"
+if [[ "$output" != "hello" ]]; then
+  echo "Expected 'hello', got '$output'"
+  exit 1
+fi
+
 script="$(rlocation rules_multirun/tests/multirun_parallel_no_buffer.bash)"
 parallel_output="$($script)"
 if [[ -n "$parallel_output" ]]; then


### PR DESCRIPTION
This is a PoC about how `jobs` can be used to control concurrency limit.

Currently `jobs` can either be 0 (no limit, spawn/fork as many as possible), or 1 (serial). This PR uses a thread pool to control the max number of concurrently running processes.

This PR also solves a deadlock when a child process outputs too much data that don't fit into output buffer.