### PR TITLE
Add the ability to pipe stdin to parallel job sets

### DIFF
--- a/doc/README.md
+++ b/doc/README.md
@@ -96,7 +96,7 @@ load("@rules_multirun//:defs.bzl", "multirun", command = "command_force_opt")
 <pre>
 load("@rules_multirun//:defs.bzl", "multirun")
 
-multirun(<a href="#multirun-name">name</a>, <a href="#multirun-data">data</a>, <a href="#multirun-buffer_output">buffer_output</a>, <a href="#multirun-commands">commands</a>, <a href="#multirun-jobs">jobs</a>, <a href="#multirun-keep_going">keep_going</a>, <a href="#multirun-print_command">print_command</a>)
+multirun(<a href="#multirun-name">name</a>, <a href="#multirun-data">data</a>, <a href="#multirun-buffer_output">buffer_output</a>, <a href="#multirun-commands">commands</a>, <a href="#multirun-forward_stdin">forward_stdin</a>, <a href="#multirun-jobs">jobs</a>, <a href="#multirun-keep_going">keep_going</a>, <a href="#multirun-print_command">print_command</a>)
 </pre>
 
 A multirun composes multiple command rules in order to run them in a single
@@ -156,6 +156,7 @@ multiple tools.
 | <a id="multirun-data"></a>data |  The list of files needed by the commands at runtime. See general comments about `data` at https://docs.bazel.build/versions/master/be/common-definitions.html#common-attributes   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
 | <a id="multirun-buffer_output"></a>buffer_output |  Buffer the output of the commands and print it after each command has finished. Only for parallel execution.   | Boolean | optional |  `False`  |
 | <a id="multirun-commands"></a>commands |  Targets to run   | <a href="https://bazel.build/concepts/labels">List of labels</a> | optional |  `[]`  |
+| <a id="multirun-forward_stdin"></a>forward_stdin |  Whether or not to forward stdin   | Boolean | optional |  `False`  |
 | <a id="multirun-jobs"></a>jobs |  The expected concurrency of targets to be executed. Default is set to 1 which means sequential execution. Setting to 0 means that there is no limit concurrency.   | Integer | optional |  `1`  |
 | <a id="multirun-keep_going"></a>keep_going |  Keep going after a command fails. Only for sequential execution.   | Boolean | optional |  `False`  |
 | <a id="multirun-print_command"></a>print_command |  Print what command is being run before running it.   | Boolean | optional |  `True`  |

--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -63,7 +63,7 @@ def _perform_concurrently(commands: List[Command], print_command: bool, buffer_o
 
     threads = []
     if forward_stdin:
-        stdin_thread = threading.Thread(target=_forward_stdin, args=(processes))
+        stdin_thread = threading.Thread(target=_forward_stdin, args=(processes,))
         stdin_thread.start()
         threads.append(stdin_thread)
 

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -100,6 +100,8 @@ def _multirun_impl(ctx):
 
     if ctx.attr.jobs < 0:
         fail("'jobs' attribute should be at least 0")
+    elif ctx.attr.jobs > 0 and ctx.attr.forward_stdin:
+        fail("'forward_stdin' can only apply to parallel jobs ('jobs' === 0)")
 
     jobs = ctx.attr.jobs
     instructions = struct(
@@ -108,6 +110,7 @@ def _multirun_impl(ctx):
         print_command = ctx.attr.print_command,
         keep_going = ctx.attr.keep_going,
         buffer_output = ctx.attr.buffer_output,
+        forward_stdin = ctx.attr.forward_stdin,
         workspace_name = ctx.workspace_name,
     )
     ctx.actions.write(
@@ -171,6 +174,10 @@ def multirun_with_transition(cfg, allowlist = None):
         "buffer_output": attr.bool(
             default = False,
             doc = "Buffer the output of the commands and print it after each command has finished. Only for parallel execution.",
+        ),
+        "forward_stdin": attr.bool(
+            default = False,
+            doc = "Whether or not to forward stdin",
         ),
         "_bash_runfiles": attr.label(
             default = Label("@bazel_tools//tools/bash/runfiles"),

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -35,6 +35,38 @@ command(
 )
 
 sh_binary(
+    name = "echo_stdin",
+    srcs = ["echo_stdin.sh"],
+    visibility = ["//:__subpackages__"],
+)
+
+command(
+    name = "echo_stdin_cmd",
+    command = "echo_stdin",
+)
+
+sh_binary(
+    name = "echo_stdin2",
+    srcs = ["echo_stdin2.sh"],
+    visibility = ["//:__subpackages__"],
+)
+
+command(
+    name = "echo_stdin2_cmd",
+    command = "echo_stdin2",
+)
+
+multirun(
+    name = "multirun_echo_stdin",
+    commands = [
+        "echo_stdin_cmd",
+        "echo_stdin2_cmd",
+    ],
+    forward_stdin = True,
+    jobs = 0,
+)
+
+sh_binary(
     name = "validate_args",
     srcs = ["validate-args.sh"],
 )
@@ -205,6 +237,7 @@ sh_test(
         ":multirun_binary_args",
         ":multirun_binary_args_location",
         ":multirun_binary_env",
+        ":multirun_echo_stdin",
         ":multirun_parallel",
         ":multirun_parallel_no_buffer",
         ":multirun_parallel_with_output",

--- a/tests/echo_stdin.sh
+++ b/tests/echo_stdin.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+std_in=$(</dev/stdin)
+
+printf 'From stdin: %s\n' "${std_in}"
+
+exit 0

--- a/tests/echo_stdin2.sh
+++ b/tests/echo_stdin2.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+
+std_in=$(</dev/stdin)
+
+printf 'From stdin2: %s\n' "${std_in}"
+
+exit 0

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -116,9 +116,10 @@ fi
 
 script=$(rlocation rules_multirun/tests/multirun_echo_stdin.bash)
 root_output=$( $script <<< "foobar" )
-expectation="From stdin: foobar
-From stdin2: foobar"
-if [[ "$root_output" != "$expectation" ]]; then
-  echo "Expected '$expectation' from root, got '$root_output'"
-  exit 1
-fi
+expectations=("From stdin: foobar" "From stdin2: foobar")
+for expectation in "${expectations[@]}"; do
+  if [[ "$root_output" != *"${expectation}"* ]]; then
+    echo "Expected '${expectation}' to be in '$root_output'"
+    exit 1
+  fi
+done

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -113,3 +113,12 @@ if [[ "$root_output" != "hello" ]]; then
   echo "Expected 'hello' from root, got '$root_output'"
   exit 1
 fi
+
+script=$(rlocation rules_multirun/tests/multirun_echo_stdin.bash)
+root_output=$( $script <<< "foobar" )
+expectation="From stdin: foobar
+From stdin2: foobar"
+if [[ "$root_output" != "$expectation" ]]; then
+  echo "Expected '$expectation' from root, got '$root_output'"
+  exit 1
+fi


### PR DESCRIPTION
`This` is really useful for running multiple ibazel-compatible commands.

For example, the following BUILD file scenario would be very useful:

```
js_run_devserver(
     name = "backend_devserver",
     ....
)

command(
    name = "backend",
    command = ":backend_devserver",
    tags = ["ibazel_notify_changes"],
)

js_run_devserver(
     name = "frontend_devserver",
     ....
)

command(
    name = "frontend",
    command = ":frontend_devserver",
    tags = ["ibazel_notify_changes"],
)

multirun(
    name = "stack",
    commands = [
        "backend",
        "frontend",
    ],
    forward_stdin = True,
    jobs = 0,
    tags = ["ibazel_notify_changes"],
)
```

Fixes https://github.com/keith/rules_multirun/issues/63