### PR TITLE
Send interrupt signal instead of killing process on keyboard interrupt.

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -2,6 +2,7 @@ import json
 import os
 import shutil
 import subprocess
+import signal
 import sys
 import threading
 import platform
@@ -84,7 +85,7 @@ def _perform_concurrently(commands: List[Command], print_command: bool, buffer_o
                 success = False
     except KeyboardInterrupt:
         for command, process in processes:
-            process.kill()
+            process.send_signal(signal.SIGINT)
             process.wait()
         success = False
     finally:

--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -1,8 +1,8 @@
 import json
 import os
+import signal
 import shutil
 import subprocess
-import signal
 import sys
 import threading
 import platform


### PR DESCRIPTION
Killing child process is a bit unsynced with CTRL+C default behaviour, it's better to send SIGINT to the process.