### PR TITLE
fix: Handle RunEnvironmentInfo

### DIFF
--- a/multirun.bzl
+++ b/multirun.bzl
@@ -24,7 +24,10 @@ def _binary_args_env_aspect_impl(target, ctx):
 
     is_executable = target.files_to_run != None and target.files_to_run.executable != None
     args = getattr(ctx.rule.attr, "args", [])
-    env = getattr(ctx.rule.attr, "env", {})
+    env = dict(getattr(ctx.rule.attr, "env", {}))
+
+    if RunEnvironmentInfo in target:
+        env.update(target[RunEnvironmentInfo].environment)
 
     if is_executable and (args or env):
         expansion_targets = getattr(ctx.rule.attr, "data", [])

--- a/tests/BUILD
+++ b/tests/BUILD
@@ -1,4 +1,5 @@
 load("//:defs.bzl", "command", "command_force_opt", "multirun")
+load(":custom_executable.bzl", "custom_executable")
 load(":transitions.bzl", "command_lambda", "multirun_lambda")
 
 sh_binary(
@@ -194,6 +195,15 @@ multirun(
     commands = [":validate_binary_env"],
 )
 
+custom_executable(
+    name = "validate_custom_executable_rule_env",
+)
+
+multirun(
+    name = "multirun_custom_executable_rule_env",
+    commands = [":validate_custom_executable_rule_env"],
+)
+
 platform(
     name = "lambda",
     constraint_values = [
@@ -259,6 +269,7 @@ sh_test(
         ":multirun_binary_args",
         ":multirun_binary_args_location",
         ":multirun_binary_env",
+        ":multirun_custom_executable_rule_env",
         ":multirun_echo_stdin",
         ":multirun_parallel",
         ":multirun_parallel_no_buffer",

--- a/tests/custom_executable.bzl
+++ b/tests/custom_executable.bzl
@@ -1,0 +1,45 @@
+"Simple executable rule to exercise RunEnvironmentInfo handling"
+
+def _custom_executable_impl(ctx):
+    executable = ctx.actions.declare_file(ctx.label.name + ".bash")
+
+    # Create the runfiles object
+    runfiles = ctx.attr._bash_runfiles[DefaultInfo].default_runfiles
+
+    # Write the script content to the executable
+    ctx.actions.write(
+        output = executable,
+        content = """#!/bin/bash
+
+set -euo pipefail
+
+if [[ "$FOO_ENV" != "foo" ]]; then
+  echo "error: expected FOO_ENV to be 'foo', got '$FOO_ENV'"
+  exit 1
+fi
+""",
+        is_executable = True,
+    )
+
+    return [
+        DefaultInfo(
+            files = depset([executable]),
+            runfiles = runfiles,
+            executable = executable,
+        ),
+        RunEnvironmentInfo(
+            environment = {
+                "FOO_ENV": "foo",
+            },
+        ),
+    ]
+
+custom_executable = rule(
+    implementation = _custom_executable_impl,
+    attrs = {
+        "_bash_runfiles": attr.label(
+            default = "@bazel_tools//tools/bash/runfiles",
+        ),
+    },
+    executable = True,
+)

--- a/tests/test.sh
+++ b/tests/test.sh
@@ -38,6 +38,9 @@ $script
 script=$(rlocation rules_multirun/tests/multirun_binary_args_location.bash)
 $script
 
+script=$(rlocation rules_multirun/tests/multirun_custom_executable_rule_env.bash)
+$script
+
 script="$(rlocation rules_multirun/tests/multirun_parallel.bash)"
 parallel_output="$($script)"
 if [[ -n "$parallel_output" ]]; then


### PR DESCRIPTION
Executable rules can include a [RunEnvironmentInfo](https://bazel.build/rules/lib/providers/RunEnvironmentInfo) provider to set envs. These envs are detected and included with explicitly defined envs on the target when defining the multirun commands.

Because bazel allows for this provider, it is nice for rules_multirun to handle it. I ran into a situation where a 3rd party ruleset uses this as part of a run action and there is no way to provide the correct value by wrapping in a `command` as the env is internal to the ruleset.