### PR TITLE
Fix deadlock with large output

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -34,7 +34,7 @@ def _run_command(command: Command, block: bool, **kwargs) -> Union[int, subproce
     if block:
         return subprocess.check_call(args, env=env)
     else:
-        return subprocess.Popen(args, env=env, **kwargs)
+        return subprocess.Popen(args, env=env, text=True, universal_newlines=True, **kwargs)
 
 def _forward_stdin(procs: List[Tuple[Command, subprocess.Popen]]) -> None:
     for line in sys.stdin.readlines():
@@ -54,7 +54,7 @@ def _perform_concurrently(commands: List[Command], print_command: bool, buffer_o
              "stdout" : subprocess.PIPE,
              "stderr" : subprocess.STDOUT
         }
-    
+
     if forward_stdin:
         kwargs["stdin"] = subprocess.PIPE
 
@@ -73,13 +73,16 @@ def _perform_concurrently(commands: List[Command], print_command: bool, buffer_o
     success = True
     try:
         for command, process in processes:
-            process.wait()
             if print_command and buffer_output:
                 print(command.tag, flush=True)
 
-            stdout = process.communicate()[0]
+            stdout = ""
+            for line in iter(process.stdout.readline, ''):
+                stdout += line
+
+            process.wait()
             if stdout:
-                print(stdout.decode().strip(), flush=True)
+                print(stdout.strip(), flush=True)
 
             if process.returncode != 0:
                 success = False


### PR DESCRIPTION
Specifically in the docs of `process.wait()` there is:

```
Note This will deadlock when using stdout=PIPE or stderr=PIPE and the
child process generates enough output to a pipe such that it blocks
waiting for the OS pipe buffer to accept more data. Use
Popen.communicate() when using pipes to avoid that.
```

Now we read stdout as it comes in and wait for the process afterwards.
