### PR TITLE
fix: `BAZEL_SH` must take precedence on Windows

### DIFF
--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -22,9 +22,9 @@ class Command(NamedTuple):
 
 def _run_command(command: Command, block: bool, **kwargs) -> Union[int, subprocess.Popen]:
     if platform.system() == "Windows":
-        bash = shutil.which("bash.exe")
+        bash = os.environ.get("BAZEL_SH") or shutil.which("bash")
         if not bash:
-            raise SystemExit("error: bash.exe not found in PATH")
+            raise SystemExit("error: bash not found. On Windows, install MSYS2, Git Bash or Cygwin and set BAZEL_SH environment variable.")
 
         args = [bash, "-c", f'{command.path} "$@"', "--"] + command.args
     else:

--- a/internal/multirun.py
+++ b/internal/multirun.py
@@ -22,7 +22,7 @@ class Command(NamedTuple):
 
 def _run_command(command: Command, block: bool, **kwargs) -> Union[int, subprocess.Popen]:
     if platform.system() == "Windows":
-        bash = os.environ.get("BAZEL_SH") or shutil.which("bash")
+        bash = os.environ.get("BAZEL_SH") or shutil.which("bash.exe")
         if not bash:
             raise SystemExit("error: bash not found. On Windows, install MSYS2, Git Bash or Cygwin and set BAZEL_SH environment variable.")
 


### PR DESCRIPTION
Related to 

- https://github.com/keith/rules_multirun/issues/56
- https://github.com/bazel-contrib/bazel-gazelle/blob/master/internal/gazelle.bash.in
- https://github.com/keith/rules_multirun/blob/main/internal/constants.bzl