### PR TITLE
Expand make variables in environment and arguments

### DIFF
--- a/command.bzl
+++ b/command.bzl
@@ -44,7 +44,7 @@ def _command_impl(ctx):
         for k, v in ctx.attr.environment.items()
     ]
     str_args = [
-        "%s" % shell.quote(ctx.expand_location(v, targets = expansion_targets))
+        "%s" % shell.quote(ctx.expand_make_variables("arguments", ctx.expand_location(v, targets = expansion_targets), {}))
         for v in ctx.attr.arguments
     ]
     cd_command = ""

--- a/command.bzl
+++ b/command.bzl
@@ -40,7 +40,7 @@ def _command_impl(ctx):
     expansion_targets = ctx.attr.data
 
     str_env = [
-        "export %s=%s" % (k, shell.quote(ctx.expand_location(v, targets = expansion_targets)))
+        "export %s=%s" % (k, shell.quote(ctx.expand_make_variables("environment", ctx.expand_location(v, targets = expansion_targets), {})))
         for k, v in ctx.attr.environment.items()
     ]
     str_args = [


### PR DESCRIPTION
This way you can use `$(BINDIR)` and it will be correctly replaced
