### PR TITLE
Fix multirun runner cfg

### DIFF
--- a/multirun.bzl
+++ b/multirun.bzl
@@ -187,7 +187,7 @@ def multirun_with_transition(cfg, allowlist = None):
         ),
         "_runner": attr.label(
             default = Label("//internal:multirun"),
-            cfg = "exec",
+            cfg = "target",
             executable = True,
         ),
     }


### PR DESCRIPTION
If you use cross platform remote exec, this was wrong. The runner is run
as part of bazel run, not during the action, so this needs to be built
for the target otherwise you get a different platform's python
interpreter.
