### PR TITLE
fix: use merge_all() to avoid O(n)-depth runfiles NestedSet nesting

### DIFF
--- a/command.bzl
+++ b/command.bzl
@@ -36,12 +36,12 @@ def _expand_and_quote(*, ctx, attr, string, targets):
         return shell.quote(expanded)
 
 def _command_impl(ctx):
-    runfiles = ctx.runfiles().merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
+    transitive_runfiles = [ctx.attr._bash_runfiles[DefaultInfo].default_runfiles]
 
     for data_dep in ctx.attr.data:
         default_runfiles = data_dep[DefaultInfo].default_runfiles
         if default_runfiles != None:
-            runfiles = runfiles.merge(default_runfiles)
+            transitive_runfiles.append(default_runfiles)
 
     command = ctx.attr.command if type(ctx.attr.command) == "Target" else ctx.attr.command[0]
     default_info = command[DefaultInfo]
@@ -49,7 +49,9 @@ def _command_impl(ctx):
 
     default_runfiles = default_info.default_runfiles
     if default_runfiles != None:
-        runfiles = runfiles.merge(default_runfiles)
+        transitive_runfiles.append(default_runfiles)
+
+    runfiles = ctx.runfiles().merge_all(transitive_runfiles)
 
     expansion_targets = ctx.attr.data
 

--- a/multirun.bzl
+++ b/multirun.bzl
@@ -53,14 +53,15 @@ def _multirun_impl(ctx):
     runner_info = ctx.attr._runner[DefaultInfo]
     runner_exe = runner_info.files_to_run.executable
 
-    runfiles = ctx.runfiles(files = [instructions_file, runner_exe])
-    runfiles = runfiles.merge(ctx.attr._bash_runfiles[DefaultInfo].default_runfiles)
-    runfiles = runfiles.merge(runner_info.default_runfiles)
+    transitive_runfiles = [
+        ctx.attr._bash_runfiles[DefaultInfo].default_runfiles,
+        runner_info.default_runfiles,
+    ]
 
     for data_dep in ctx.attr.data:
         default_runfiles = data_dep[DefaultInfo].default_runfiles
         if default_runfiles != None:
-            runfiles = runfiles.merge(default_runfiles)
+            transitive_runfiles.append(default_runfiles)
 
     commands = []
     tagged_commands = []
@@ -87,7 +88,7 @@ def _multirun_impl(ctx):
 
         default_runfiles = default_info.default_runfiles
         if default_runfiles != None:
-            runfiles = runfiles.merge(default_runfiles)
+            transitive_runfiles.append(default_runfiles)
 
         if CommandInfo in command:
             tag = command[CommandInfo].description
@@ -100,6 +101,8 @@ def _multirun_impl(ctx):
             args = args,
             env = env,
         ))
+
+    runfiles = ctx.runfiles(files = [instructions_file, runner_exe]).merge_all(transitive_runfiles)
 
     if ctx.attr.jobs < 0:
         fail("'jobs' attribute should be at least 0")


### PR DESCRIPTION
## Summary

- Replace sequential `runfiles.merge()` calls in loops with collecting into a list + single `merge_all()` call in both `multirun.bzl` and `command.bzl`
- This changes the NestedSet depth from O(n) to O(1), preventing `StackOverflowError` in large multirun targets

## Problem

When a `multirun` target has many commands (e.g. 1000+), the current code calls `runfiles.merge()` in a loop:

```python
for command in ctx.attr.commands:
    runfiles = runfiles.merge(default_info.default_runfiles)
```

Each `merge()` wraps the previous result as a transitive child, creating a linear chain of NestedSets with depth proportional to the number of commands. When Bazel later fingerprints this structure via the recursive `NestedSetFingerprintCache.addToFingerprint`, it overflows the JVM stack.

We hit this as a `java.lang.StackOverflowError` (1022 recursive frames deep) when upgrading to Bazel 9.1.1 in a monorepo with ~1000 deploy targets aggregated via a single `multirun` target. The crash is in Bazel's internal NestedSet fingerprinting:

```
FATAL: bazel crashed due to an internal error. Printing stack trace:
java.lang.StackOverflowError
	at c.g.d.b.l.collect.nestedset.DigestMap.readDigest(DigestMap.java:69)
	at c.g.d.b.l.collect.nestedset.NestedSetFingerprintCache.addToFingerprint(NestedSetFingerprintCache.java:106)
	at c.g.d.b.l.collect.nestedset.NestedSetFingerprintCache.addToFingerprint(NestedSetFingerprintCache.java:109)
	... (1022 frames)
```

## Fix

Collect all runfiles objects into a flat list, then call `merge_all()` once. This produces a shallow NestedSet tree regardless of the number of commands.

`merge_all()` has been available since Bazel 5.x.

## Test plan

- [ ] Existing tests continue to pass
- [x] Verified against a monorepo with 1000+ commands that previously hit `StackOverflowError`

🤖 Generated with [Claude Code](https://claude.com/claude-code)